### PR TITLE
Fix: Allows setting adaptive content as other statuses (fixes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ The main configuration for this extension is in `course.json`:
 ```
 If `_shouldSubmitScore` is set to `true`, the score the learner attains in the diagnostic assessment will be reported to the LMS. Note that, if the course contains a final assessment, and the learner is required to complete that, the score for the final assessment will overwrite any score recording from their attempt at the diagnostic assessment. This is because SCORM only allows for one score per SCO to be recorded.
 
+The setting `_setPageStatusAs` allows a setting to either mark all adaptive content as `complete`, `optional` or `unavailable` based upon diagnostic assessment results.
+
+If `_shouldSubmitScore` is set to `true`, the score the learner attains in the diagnostic assessment will be reported to the LMS. Note that, if the course contains a final assessment, and the learner is required to complete that, the score for the final assessment will overwrite any score recording from their attempt at the diagnostic assessment. This is because SCORM only allows for one score per SCO to be recorded.
+
 The setting `_diagnosticAssessmentId` is the 'assessment ID' of the diagnostic assessment. This setting is mandatory. If the course includes a final assessment, you must set `_finalAssessmentId` to the 'assessment ID' of the final assessment. These settings are vital to allow the extension to know which assessment is which!
 
 ## Learner Journey Scenarios
@@ -87,7 +91,7 @@ The following scenarios are all supported by this extension
 The diagnostic assessment functionality is handled entirely by the standard [adapt assessment extension](https://github.com/adaptlearning/adapt-contrib-assessment). However, there are some configuration options that need to be set correctly for it to be able to function as a 'diagnostic assessment'...
 
 The diagnostic assessment **must**:
-* use the [adapt-diagnosticResults](https://github.com/cgkineo/adapt-diagnosticResults) component to show its results, rather than the standard adapt-contrib-assessmentResults component!
+* use the adapt-diagnosticResults component to show its results, rather than the standard adapt-contrib-assessmentResults component!
 * be set to 1 attempt only (set `_attempts` to `1`)
 * have `_isResetOnRevisit` set to `false`
 * have `_includeInTotalScore` set to `false`

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
         "url": "git://github.com/cgkineo/adapt-adaptiveContent.git"
     },
     "framework": ">=5.5",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "displayName": "Adaptive Content",
     "extension": "adaptiveContent",
     "description": "An extension that allows content objects and final assessments to be hidden based on the learner's performance in an assessment",

--- a/example.json
+++ b/example.json
@@ -2,6 +2,8 @@
 "_adaptiveContent": {
     "_isEnabled": true,
     "_shouldSubmitScore": true,
+    "_comment": "Options include 'complete', 'unavailable' & 'optional'",
+    "_setPageStatusAs": "complete",
     "_diagnosticAssessmentId": "diagnostic",
     "_finalAssessmentId": "final"
 }

--- a/properties.schema
+++ b/properties.schema
@@ -34,6 +34,23 @@
                                     "validators": [],
                                     "help": "Controls whether the score the learner attains in the diagnostic assessment should be sent to the LMS or not. Note that if the course contains a final assessment, and the learner is required to take it, that score will overwrite the score for the diagnostic assessment when they do"
                                 },
+                                "_setPageStatusAs": {
+                                    "type": "string",
+                                    "required": true,
+                                    "default": "unavailable",
+                                    "title": "Set content status as?",
+                                    "enum": ["complete", "optional", "unavailable"],
+                                    "inputType": {
+                                        "type": "Select",
+                                        "options": [
+                                        "complete",
+                                        "optional",
+                                        "unavailable"
+                                        ]
+                                    },
+                                    "validators": [],
+                                    "help": "Sets a status for all adaptive content as complete, optional or unavailable based upon successfully meeting diagnostic criteria."
+                                },
                                 "_diagnosticAssessmentId": {
                                     "type": "string",
                                     "default": "",


### PR DESCRIPTION
Allows a setting to either mark all adaptive content as complete, optional or unavailable based upon diagnostic assessment results.